### PR TITLE
Remove extra setupWorker statement

### DIFF
--- a/src/test/server.js
+++ b/src/test/server.js
@@ -2,8 +2,6 @@ import {setupWorker} from 'msw'
 import {handlers} from './server-handlers'
 import {homepage} from '../../package.json'
 
-setupWorker(...handlers)
-
 const fullUrl = new URL(homepage)
 
 const server = setupWorker(...handlers)


### PR DESCRIPTION
setupWroker is not required to be called twice. 
There are two setupWorker statements, one without any return being assigned and another one is with return assigned to server const.